### PR TITLE
Added path resolution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
-var addon = _interopRequire(require("../build/Release/addon"));
+var path = requrire("path");
+var addon = _interopRequire(require(path.resolve(__dirname, "../build/Release/addon")));
 
 var isInitialized = false;
 


### PR DESCRIPTION
It seems that this require statement fails when being referenced from outside the module directory. I've added some extra pathing safety here to ensure that the require statement points to the intended folder.

Addresses https://github.com/nebrius/raspi-io/issues/40
